### PR TITLE
診断ページに「戻る」を追加する

### DIFF
--- a/src/components/__tests__/__snapshots__/storyshots.test.ts.snap
+++ b/src/components/__tests__/__snapshots__/storyshots.test.ts.snap
@@ -1,54 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Storyshots App Show App 1`] = `
-Array [
-  <div
-    style={
-      Object {
-        "position": "relative",
-        "zIndex": 0,
-      }
-    }
-  >
-    <div
-      className="container"
-    >
-      <div>
-        <a
-          href="/counter"
-          onClick={[Function]}
-        >
-          Counter
-        </a>
-      </div>
-    </div>
-  </div>,
-  <button
-    className="info__show-button"
-    onClick={[Function]}
-    style={
-      Object {
-        "background": "#027ac5",
-        "border": "none",
-        "borderRadius": "0 0 0 5px",
-        "color": "#fff",
-        "cursor": "pointer",
-        "display": "block",
-        "fontFamily": "sans-serif",
-        "fontSize": "12px",
-        "padding": "5px 15px",
-        "position": "fixed",
-        "right": 0,
-        "top": 0,
-      }
-    }
-    type="button"
-  >
-    Show Info
-  </button>,
-]
-`;
-
 exports[`Storyshots Footer Show App 1`] = `
 Array [
   <div
@@ -284,7 +235,7 @@ Array [
     }
   >
     <button
-      className="sc-gqjmRU dYKCAa"
+      className="sc-gqjmRU dYmsGr"
       disabled={true}
     >
       次へ進む
@@ -327,7 +278,7 @@ Array [
     }
   >
     <button
-      className="sc-gqjmRU jzwNPt"
+      className="sc-gqjmRU blftXP"
       disabled={false}
     >
       次へ進む

--- a/src/features/analysis/Analysis.tsx
+++ b/src/features/analysis/Analysis.tsx
@@ -53,7 +53,7 @@ const Analysis: FC<{}> = () => {
     });
   };
 
-  const onClick = () => {
+  const onNextClicked = () => {
     setCurrentSliceStart(currentPage * perPage);
     setCurrentSliceEnd((currentPage + 1) * perPage);
     setCurrentPage(currentPage + 1);
@@ -65,13 +65,15 @@ const Analysis: FC<{}> = () => {
     });
   };
 
+  const onBackClicked = () => {};
+
   const nextButton =
     currentPage === pageCount ? (
       <NextButton to="/result" disabled={disableNextButton}>
         診断結果へ
       </NextButton>
     ) : (
-      <NextButton onClick={onClick} disabled={disableNextButton}>
+      <NextButton onClick={onNextClicked} disabled={disableNextButton}>
         次へ進む
       </NextButton>
     );
@@ -90,6 +92,7 @@ const Analysis: FC<{}> = () => {
         onChanged={onChanged}
       />
       {nextButton}
+      <BackButton onClick={onBackClicked}>戻る</BackButton>
     </Section>
   );
 };
@@ -107,6 +110,19 @@ const Description = styled.p`
   color: ${theme.text.alt};
   font-size: 14px;
   margin: 4em auto 1em;
+`;
+
+const BackButton = styled.button`
+  align-items: center;
+  background: transparent;
+  border: 1px solid ${theme.bg.border};
+  border-radius: 8px;
+  color: ${theme.text.secondary};
+  font-size: 12px;
+  font-weight: 400;
+  margin-bottom: 24px;
+  padding: 8px;
+  text-decoration: none;
 `;
 
 export default Analysis;

--- a/src/features/analysis/Analysis.tsx
+++ b/src/features/analysis/Analysis.tsx
@@ -65,7 +65,15 @@ const Analysis: FC<{}> = () => {
     });
   };
 
-  const onBackClicked = () => {};
+  const onBackClicked = () => {
+    setCurrentSliceStart((currentPage - 2) * perPage);
+    setCurrentSliceEnd((currentPage - 1) * perPage);
+    setCurrentPage(currentPage - 1);
+
+    scroll.scrollToTop({
+      duration: 0,
+    });
+  };
 
   const nextButton =
     currentPage === pageCount ? (
@@ -92,7 +100,7 @@ const Analysis: FC<{}> = () => {
         onChanged={onChanged}
       />
       {nextButton}
-      <BackButton onClick={onBackClicked}>戻る</BackButton>
+      {currentPage > 1 && <BackButton onClick={onBackClicked}>戻る</BackButton>}
     </Section>
   );
 };

--- a/src/features/analysis/Analysis.tsx
+++ b/src/features/analysis/Analysis.tsx
@@ -27,6 +27,20 @@ const Analysis: FC<{}> = () => {
 
   const pageCount = Math.ceil(questions.length / perPage);
 
+  const calculateNextSliceOptions = (currentIndex: number, length: number) => {
+    return {
+      start: currentIndex * length,
+      end: (currentIndex + 1) * length,
+    };
+  };
+
+  const calculateBackSliceOptions = (currentIndex: number, length: number) => {
+    return {
+      start: (currentIndex - 2) * length,
+      end: (currentIndex - 1) * length,
+    };
+  };
+
   useEffect(() => {
     dispatch(analysis.actions.fetchQuestions());
     dispatch(analysis.actions.fetchChoices());
@@ -54,11 +68,18 @@ const Analysis: FC<{}> = () => {
   };
 
   const onNextClicked = () => {
-    setCurrentSliceStart(currentPage * perPage);
-    setCurrentSliceEnd((currentPage + 1) * perPage);
+    const nextSliceOptions = calculateNextSliceOptions(currentPage, perPage);
+
+    setCurrentSliceStart(nextSliceOptions.start);
+    setCurrentSliceEnd(nextSliceOptions.end);
     setCurrentPage(currentPage + 1);
 
-    dispatch(analysis.actions.updateDisableNextButton(true));
+    dispatch(
+      analysis.actions.updateDisableNextButton({
+        start: nextSliceOptions.start,
+        end: nextSliceOptions.end,
+      }),
+    );
 
     scroll.scrollToTop({
       duration: 0,
@@ -66,9 +87,18 @@ const Analysis: FC<{}> = () => {
   };
 
   const onBackClicked = () => {
-    setCurrentSliceStart((currentPage - 2) * perPage);
-    setCurrentSliceEnd((currentPage - 1) * perPage);
+    const backSliceOptions = calculateBackSliceOptions(currentPage, perPage);
+
+    setCurrentSliceStart(backSliceOptions.start);
+    setCurrentSliceEnd(backSliceOptions.end);
     setCurrentPage(currentPage - 1);
+
+    dispatch(
+      analysis.actions.updateDisableNextButton({
+        start: backSliceOptions.start,
+        end: backSliceOptions.end,
+      }),
+    );
 
     scroll.scrollToTop({
       duration: 0,

--- a/src/features/analysis/Analysis.tsx
+++ b/src/features/analysis/Analysis.tsx
@@ -161,6 +161,7 @@ const BackButton = styled.button`
   margin-bottom: 24px;
   padding: 8px;
   text-decoration: none;
+  cursor: pointer;
 `;
 
 export default Analysis;

--- a/src/features/analysis/NextButton.tsx
+++ b/src/features/analysis/NextButton.tsx
@@ -39,6 +39,7 @@ const StyledButton = styled.button<StyledButtonProps>`
   margin: 24px 0 24px;
   padding: 16px;
   text-decoration: none;
+  cursor: pointer;
 `;
 
 export default NextButton;

--- a/src/features/analysis/NextButton.tsx
+++ b/src/features/analysis/NextButton.tsx
@@ -30,7 +30,7 @@ type StyledButtonProps = {
 const StyledButton = styled.button<StyledButtonProps>`
   align-items: center;
   background-color: ${props =>
-    props.disabled ? theme.colors.disabled : theme.colors.pink};
+    props.disabled ? theme.bg.disabled : theme.colors.pink};
   border: none;
   border-radius: 8px;
   color: ${theme.text.reverse};

--- a/src/features/analysis/analysisSlice.ts
+++ b/src/features/analysis/analysisSlice.ts
@@ -26,6 +26,12 @@ export type AnswersPayload = {
   start: number;
   end: number;
 };
+
+export type DisableNextButton = {
+  start: number;
+  end: number;
+};
+
 const analysis = createSlice({
   name: 'analysis',
   initialState,
@@ -85,12 +91,15 @@ const analysis = createSlice({
     },
     updateDisableNextButton: (
       state: AnalysisState,
-      action: PayloadAction<boolean>,
+      action: PayloadAction<DisableNextButton>,
     ) => {
-      return {
-        ...state,
-        disableNextButton: action.payload,
-      };
+      const answeredList = state.answers
+        .slice(action.payload.start, action.payload.end)
+        .map(answer => answer.choiceId !== '');
+
+      const disableNextButton = answeredList.indexOf(false) !== -1;
+
+      return { ...state, disableNextButton };
     },
   },
 });

--- a/src/theme/index.ts
+++ b/src/theme/index.ts
@@ -4,6 +4,8 @@ const theme: DefaultTheme = {
   bg: {
     default: '#FFFFFF',
     alt: '#fafafa',
+    disabled: '#eeeeee',
+    border: '#EBECED',
   },
   colors: {
     white: '#FFFFFF',
@@ -11,7 +13,6 @@ const theme: DefaultTheme = {
     pink: '#f67280',
     darkpink: '#c06c84',
     purple: '#6c567b',
-    disabled: '#eeeeee',
   },
   text: {
     default: '#24292E',

--- a/src/theme/styled.d.ts
+++ b/src/theme/styled.d.ts
@@ -5,6 +5,8 @@ declare module 'styled-components' {
     bg: {
       default: string;
       alt: string;
+      border: string;
+      disabled: string;
     };
     colors: {
       white: string;
@@ -12,7 +14,6 @@ declare module 'styled-components' {
       pink: string;
       darkpink: string;
       purple: string;
-      disabled: string;
     };
     text: {
       default: string;


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/love-psychology-web/issues/25

# Doneの定義
https://github.com/nekochans/love-psychology-web/issues/25 の完了の定義が満たされていること

# スクリーンショット
<img width="484" alt="スクリーンショット 2020-02-01 15 11 14" src="https://user-images.githubusercontent.com/32682645/73587924-22d8ad80-4505-11ea-890b-924e5d88c683.png">

# 変更点概要

## 仕様的変更点概要
診断ページに「戻る」ボタンを追加。

## 技術的変更点概要
「戻る」ボタンを押下した際、ユーザの回答はStoreに保持されたままである。
「戻る」ボタン押下によりページした際に、前のページではユーザが回答済みであるため「次に進む」ボタンが活性となるように制御を追加している。

# 補足情報
「戻る」ボタンの位置は、画面上部などに固定しておいたほうが操作しやすいかもしれない。
デザイン見直しの際に、再検討する。